### PR TITLE
Fix certificate error on mac

### DIFF
--- a/cartodb/cartodb.py
+++ b/cartodb/cartodb.py
@@ -142,7 +142,11 @@ class CartoDBAPIKey(CartoDBBase):
     def __init__(self, api_key, cartodb_domain, host='cartodb.com', protocol='https', proxy_info=None, *args, **kwargs):
         super(CartoDBAPIKey, self).__init__(cartodb_domain, host, protocol, *args, **kwargs)
         self.api_key = api_key
-        self.client = httplib2.Http()
+        
+        import certifi
+        certificate_location =  certifi.where()
+        self.client = httplib2.Http(ca_certs=certificate_location)
+
         if protocol != 'https':
             warnings.warn("you are using API key auth method with http") 
 


### PR DESCRIPTION
This fix should be validated on windows and linux

Related to https://github.com/gkudos/qgis-cartodb/issues/2

Solution according to https://github.com/kennethreitz/requests/issues/557#issuecomment-6899117
